### PR TITLE
Add local node pprof server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,19 @@ thus moving the standard forward.
 ## Getting started
 
 To run the example `evmd` chain, run the script using `./local_node.sh`
-from the root folder of the respository.
+from the root folder of the repository.
+
+`local_node.sh` starts the node with a built‑in pprof server listening on
+`localhost:6060`. While the node is running you can capture CPU and memory
+profiles with the following commands:
+
+```bash
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+go tool pprof http://localhost:6060/debug/pprof/heap
+```
+
+These profiles can be collected during a Foundry load test to identify
+bottlenecks in CPU, memory, or IO.
 
 ### Testing
 

--- a/evmd/cmd/evmd/config/evmd_config.go
+++ b/evmd/cmd/evmd/config/evmd_config.go
@@ -96,6 +96,7 @@ func InitAppConfig(denom string, evmChainID uint64) (string, interface{}) {
 		EVM     cosmosevmserverconfig.EVMConfig
 		JSONRPC cosmosevmserverconfig.JSONRPCConfig
 		TLS     cosmosevmserverconfig.TLSConfig
+		Pprof   cosmosevmserverconfig.PprofConfig
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -123,6 +124,7 @@ func InitAppConfig(denom string, evmChainID uint64) (string, interface{}) {
 		EVM:     *evmCfg,
 		JSONRPC: *cosmosevmserverconfig.DefaultJSONRPCConfig(),
 		TLS:     *cosmosevmserverconfig.DefaultTLSConfig(),
+		Pprof:   *cosmosevmserverconfig.DefaultPprofConfig(),
 	}
 
 	customAppTemplate := serverconfig.DefaultConfigTemplate +

--- a/local_node.sh
+++ b/local_node.sh
@@ -14,6 +14,10 @@ HOMEDIR="$HOME/.evmd"
 
 BASEFEE=10000000
 
+# Pprof variables
+PPROF_ADDR="localhost:6060"
+PPROF_ENABLE=true
+
 # Path variables
 CONFIG=$HOMEDIR/config/config.toml
 APP_TOML=$HOMEDIR/config/app.toml
@@ -224,6 +228,8 @@ fi
 evmd start "$TRACE" \
 	--log_level $LOGLEVEL \
 	--minimum-gas-prices=0.0001atest \
-	--home "$HOMEDIR" \
-	--json-rpc.api eth,txpool,personal,net,debug,web3 \
-	--chain-id "$CHAINID"
+        --home "$HOMEDIR" \
+        --json-rpc.api eth,txpool,personal,net,debug,web3 \
+        --pprof.enable=$PPROF_ENABLE \
+        --pprof.address $PPROF_ADDR \
+        --chain-id "$CHAINID"

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -100,4 +100,16 @@ certificate-path = "{{ .TLS.CertificatePath }}"
 
 # Key path defines the key.pem file path for the TLS configuration.
 key-path = "{{ .TLS.KeyPath }}"
+
+###############################################################################
+###                             Pprof Configuration                         ###
+###############################################################################
+
+[pprof]
+
+# Enable defines if the pprof server should be enabled.
+enable = {{ .Pprof.Enable }}
+
+# Address defines the pprof server address to bind to.
+address = "{{ .Pprof.Address }}"
 `

--- a/server/flags/flags.go
+++ b/server/flags/flags.go
@@ -73,6 +73,12 @@ const (
 	TLSKeyPath  = "tls.key-path"
 )
 
+// Pprof flags
+const (
+	PprofEnable  = "pprof.enable"
+	PprofAddress = "pprof.address"
+)
+
 // AddTxFlags adds common flags for commands to post tx
 func AddTxFlags(cmd *cobra.Command) (*cobra.Command, error) {
 	cmd.PersistentFlags().String(flags.FlagChainID, "", "Specify Chain ID for sending Tx")


### PR DESCRIPTION
## Summary
- enable pprof server when running the local node script
- document how to collect pprof profiles

## Testing
- `go build ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a5c700d4883268515f6497e103094