### PR TITLE
Feat/improve

### DIFF
--- a/ante/evm/07_can_transfer.go
+++ b/ante/evm/07_can_transfer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/params"
 
 	anteinterfaces "github.com/cosmos/evm/ante/interfaces"
 	"github.com/cosmos/evm/utils"
@@ -17,7 +18,57 @@ import (
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// ValidateTransactionCosts checks that the sender has enough balance to cover both transaction costs and value transfer
+func ValidateTransactionCosts(
+	ctx sdk.Context,
+	evmKeeper anteinterfaces.EVMKeeper,
+	msg *core.Message,
+	txData evmtypes.TxData,
+	baseFee *big.Int,
+	rules params.Rules,
+) error {
+	// Check if max fee per gas is at least the block base fee (EIP-1559)
+	if rules.IsLondon && msg.GasFeeCap != nil && msg.GasFeeCap.Cmp(baseFee) < 0 {
+		return errorsmod.Wrapf(
+			errortypes.ErrInsufficientFee,
+			"max fee per gas less than block base fee (%s < %s)",
+			msg.GasFeeCap, baseFee,
+		)
+	}
+
+	// Get the sender's account balance
+	balance := evmKeeper.GetBalance(ctx, msg.From)
+	if balance == nil {
+		return errorsmod.Wrapf(
+			errortypes.ErrUnknownAddress,
+			"account %s does not exist",
+			msg.From.Hex(),
+		)
+	}
+
+	// Check that the transaction cost is positive
+	txCost := txData.Cost()
+	if txCost.Sign() < 0 {
+		return errorsmod.Wrapf(
+			errortypes.ErrInvalidCoins,
+			"tx cost (%s) is negative and invalid", txCost,
+		)
+	}
+
+	// Check that sender has enough balance to cover tx cost
+	// Convert balance to big.Int for comparison
+	if balance.ToBig().Cmp(txCost) < 0 {
+		return errorsmod.Wrapf(
+			errortypes.ErrInsufficientFunds,
+			"sender balance < tx cost (%s < %s)", balance, txCost,
+		)
+	}
+
+	return nil
+}
+
 // CanTransfer checks if the sender is allowed to transfer funds according to the EVM block
+// Deprecated: Use ValidateTransactionCosts instead
 func CanTransfer(
 	ctx sdk.Context,
 	evmKeeper anteinterfaces.EVMKeeper,

--- a/ante/evm/mono_decorator.go
+++ b/ante/evm/mono_decorator.go
@@ -146,6 +146,8 @@ func (md MonoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 			"failed to create an ethereum core.Message from signer %T", decUtils.Signer,
 		)
 	}
+	// Store the message in context to avoid recomputation in ApplyTransaction
+	ctx = ctx.WithValue(evmtypes.CoreMessageKey, coreMsg)
 
 	// 7. validate transaction costs (combines balance and can transfer checks)
 	if err := ValidateTransactionCosts(

--- a/ante/evm/mono_decorator.go
+++ b/ante/evm/mono_decorator.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
 
 	anteinterfaces "github.com/cosmos/evm/ante/interfaces"
@@ -138,24 +137,8 @@ func (md MonoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 	}
 
 	from := ethMsg.GetFrom()
-	fromAddr := common.BytesToAddress(from)
 
-	// 6. account balance verification
-	// We get the account with the balance from the EVM keeper because it is
-	// using a wrapper of the bank keeper as a dependency to scale all
-	// balances to 18 decimals.
-	account := md.evmKeeper.GetAccount(ctx, fromAddr)
-	if err := VerifyAccountBalance(
-		ctx,
-		md.accountKeeper,
-		account,
-		fromAddr,
-		txData,
-	); err != nil {
-		return ctx, err
-	}
-
-	// 7. can transfer
+	// 6. create core message
 	coreMsg, err := ethMsg.AsMessage(decUtils.BaseFee)
 	if err != nil {
 		return ctx, errorsmod.Wrapf(
@@ -164,13 +147,14 @@ func (md MonoDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, ne
 		)
 	}
 
-	if err := CanTransfer(
+	// 7. validate transaction costs (combines balance and can transfer checks)
+	if err := ValidateTransactionCosts(
 		ctx,
 		md.evmKeeper,
-		*coreMsg,
+		coreMsg,
+		txData,
 		decUtils.BaseFee,
-		decUtils.EvmParams,
-		decUtils.Rules.IsLondon,
+		decUtils.Rules,
 	); err != nil {
 		return ctx, err
 	}

--- a/x/vm/keeper/state_transition.go
+++ b/x/vm/keeper/state_transition.go
@@ -160,11 +160,20 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 	ethTx := msgEth.AsTransaction()
 	txConfig := k.TxConfig(ctx, ethTx.Hash())
 
-	// get the signer according to the chain rules from the config and block height
-	signer := ethtypes.MakeSigner(types.GetEthChainConfig(), big.NewInt(ctx.BlockHeight()), uint64(ctx.BlockTime().Unix())) //#nosec G115 -- int overflow is not a concern here
-	msg, err := core.TransactionToMessage(ethTx, signer, cfg.BaseFee)
-	if err != nil {
-		return nil, errorsmod.Wrap(err, "failed to return ethereum transaction as core message")
+	// Try to get decoded data from context (set by ante handler)
+	var msg *core.Message
+	if ctxMsg := ctx.Value(types.CoreMessageKey); ctxMsg != nil {
+		msg = ctxMsg.(*core.Message)
+	}
+
+	// If not in context, decode it (unreachable in normal flow, but kept for safety)
+	if msg == nil {
+		// get the signer according to the chain rules from the config and block height
+		signer := ethtypes.MakeSigner(types.GetEthChainConfig(), big.NewInt(ctx.BlockHeight()), uint64(ctx.BlockTime().Unix())) //#nosec G115 -- int overflow is not a concern here
+		msg, err = core.TransactionToMessage(ethTx, signer, cfg.BaseFee)
+		if err != nil {
+			return nil, errorsmod.Wrap(err, "failed to return ethereum transaction as core message")
+		}
 	}
 
 	// create a cache context to revert state. The cache context is only committed when both tx and hooks executed successfully.
@@ -219,14 +228,9 @@ func (k *Keeper) ApplyTransaction(ctx sdk.Context, msgEth *types.MsgEthereumTx) 
 			TransactionIndex:  txConfig.TxIndex,
 		}
 
-		signerAddr, err := signer.Sender(ethTx)
-		if err != nil {
-			return nil, errorsmod.Wrap(err, "failed to extract sender address from ethereum transaction")
-		}
-
 		// Note: PostTxProcessing hooks currently do not charge for gas
 		// and function similar to EndBlockers in abci, but for EVM transactions
-		if err = k.PostTxProcessing(tmpCtx, signerAddr, *msg, receipt); err != nil {
+		if err = k.PostTxProcessing(tmpCtx, msg.From, *msg, receipt); err != nil {
 			// If hooks returns an error, revert the whole tx.
 			res.VmError = errorsmod.Wrap(err, "failed to execute post transaction processing").Error()
 			k.Logger(ctx).Error("tx post processing failed", "error", err)

--- a/x/vm/types/key.go
+++ b/x/vm/types/key.go
@@ -62,3 +62,9 @@ func AddressStoragePrefix(address common.Address) []byte {
 func StateKey(address common.Address, key []byte) []byte {
 	return append(AddressStoragePrefix(address), key...)
 }
+
+// contextKey is a type used for context values
+type contextKey string
+
+// CoreMessageKey is the key to store core.Message in context
+const CoreMessageKey contextKey = "coreMessage"


### PR DESCRIPTION
# Summary
This PR refactors the EVM Ante Handler and state-transition logic to remove duplicated work and cut unnecessary DB read/write.

## Benchmark

### Testing Environment
- **CPU**: Apple M3 Pro
- **Go Version**: go1.23.4
- **Test Command**:
```bash
# AnteHandler
cd evmd/ante && go test -benchmem -run=^$ -bench "BenchmarkAnteHandler/tx_type_evm_transfer$" -count=5 -benchtime=10000x

# ApplyTransaction (standard test with 21k gas)
cd evmd/tests/integration && go test -benchmem -run=^$ -bench ^BenchmarkApplyTransaction$ -count=5 -benchtime=10000x
```

## Performance Improvements by Commit

### 1. Balance Consolidation (Baseline → Commit 1)
Consolidated `VerifyAccountBalance` + `CanTransfer` into `ValidateTransactionCosts`

**AnteHandler Performance:**
```
name                              old time/op    new time/op    delta
AnteHandler/tx_type_evm_transfer   65.25µs        62.77µs        -3.8%

name                              old alloc/op   new alloc/op   delta
AnteHandler/tx_type_evm_transfer   34.16Ki        19.20Ki        -43.8%

name                              old allocs/op  new allocs/op  delta
AnteHandler/tx_type_evm_transfer   583            388            -33.4%
```

**ApplyTransaction Performance:**
```
name                 old time/op    new time/op    delta
ApplyTransaction     80.69µs        81.13µs        +0.5%

name                 old alloc/op   new alloc/op   delta
ApplyTransaction     41.09Ki        41.21Ki        +0.3%

name                 old allocs/op  new allocs/op  delta
ApplyTransaction     600            603            +0.5%
```

### 2. Signature Verification Optimization (Commit 1 → Commit 2)
Removed duplicate signature verification from `ApplyTransaction`

**AnteHandler Performance:**
```
name                              old time/op    new time/op    delta
AnteHandler/tx_type_evm_transfer   62.77µs        54.01µs        -13.9%

name                              old alloc/op   new alloc/op   delta
AnteHandler/tx_type_evm_transfer   19.20Ki        19.25Ki        +0.3%

name                              old allocs/op  new allocs/op  delta
AnteHandler/tx_type_evm_transfer   388            389            +0.3%
```

**ApplyTransaction Performance:**
```
name                 old time/op    new time/op    delta
ApplyTransaction     81.13µs        31.45µs        -61.2%

name                 old alloc/op   new alloc/op   delta
ApplyTransaction     41.21Ki        38.04Ki        -7.7%

name                 old allocs/op  new allocs/op  delta
ApplyTransaction     603            526            -12.8%
```

## Key Improvements

- **Eliminated duplicate balance checks**: Removed redundant DB reads and unnecessary EVM instance creation
- **Single signature verification**: Expensive EC-verify operation now runs only once, with result passed via context

## How to Reproduce

### Baseline (main branch)
```bash
git checkout main

# AnteHandler benchmark
cd evmd/ante
go test -benchmem -run=^$ -bench "BenchmarkAnteHandler/tx_type_evm_transfer$" -count=5 -benchtime=10000x | tee baseline-ante.txt

# ApplyTransaction benchmark
cd ../tests/integration
go test -benchmem -run=^$ -bench ^BenchmarkApplyTransaction$ -count=5 -benchtime=10000x | tee baseline-apply.txt
```

### Commit 1: Balance Consolidation
```bash
git checkout 3dabff0  # fix(ante): consolidate balance checks into ValidateTransactionCosts

# AnteHandler benchmark
cd evmd/ante
go test -benchmem -run=^$ -bench "BenchmarkAnteHandler/tx_type_evm_transfer$" -count=5 -benchtime=10000x | tee commit1-ante.txt

# ApplyTransaction benchmark
cd ../tests/integration
go test -benchmem -run=^$ -bench ^BenchmarkApplyTransaction$ -count=5 -benchtime=10000x | tee commit1-apply.txt
```

### Commit 2: Signature Verification Optimization
```bash
git checkout 2ee2253  # fix(ante, vm/keeper): remove duplicate signature verification

# AnteHandler benchmark
cd evmd/ante
go test -benchmem -run=^$ -bench "BenchmarkAnteHandler/tx_type_evm_transfer$" -count=5 -benchtime=10000x | tee commit2-ante.txt

# ApplyTransaction benchmark
cd ../tests/integration
go test -benchmem -run=^$ -bench ^BenchmarkApplyTransaction$ -count=5 -benchtime=10000x | tee commit2-apply.txt
```

### Compare Results
```bash
# Compare baseline vs commit 1
benchstat baseline-ante.txt commit1-ante.txt
benchstat baseline-apply.txt commit1-apply.txt

# Compare commit 1 vs commit 2
benchstat commit1-ante.txt commit2-ante.txt
benchstat commit1-apply.txt commit2-apply.txt
```