### PR TITLE
feat(indexer/filtermaps): use filtermap instead of bloombits

### DIFF
--- a/indexer/filtermap/filtermap.go
+++ b/indexer/filtermap/filtermap.go
@@ -1,0 +1,86 @@
+package filtermap
+
+import (
+	"slices"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/filtermaps"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type FilterMap []filtermaps.FilterRow
+
+func NewFilterMap(params *Params) FilterMap {
+	return make(FilterMap, params.mapHeight)
+}
+
+func (fm FilterMap) AddLogToMap(params *Params, mapIndex uint32, lvIndex uint64, address common.Address, topics []common.Hash) {
+	addrValue := addressValue(address)
+	fm.addValue(params, mapIndex, lvIndex, addrValue)
+
+	for _, topic := range topics {
+		topicVal := topicValue(topic)
+		fm.addValue(params, mapIndex, lvIndex, topicVal)
+	}
+}
+
+func (fm FilterMap) addValue(params *Params, mapIndex uint32, lvIndex uint64, logValue common.Hash) {
+	colIndex := params.columnIndex(lvIndex, &logValue)
+
+	for layerIndex := uint32(0); ; layerIndex++ {
+		rowIdx := params.rowIndex(mapIndex, layerIndex, logValue)
+		maxLen := params.maxRowLength(layerIndex)
+
+		if fm[rowIdx] == nil {
+			fm[rowIdx] = make(filtermaps.FilterRow, 0, maxLen)
+		}
+
+		if len(fm[rowIdx]) < int(maxLen) {
+			fm[rowIdx] = append(fm[rowIdx], colIndex)
+			return
+		}
+	}
+}
+
+type LogData struct {
+	MapID      uint32
+	StartBlock uint64
+	EndBlock   uint64
+	Logs       []*ethtypes.Log
+}
+
+type potentialMatches []uint64
+
+func (params *Params) potentialMatches(rows []filtermaps.FilterRow, mapIndex uint32, logValue common.Hash) potentialMatches {
+	results := make(potentialMatches, 0, 8)
+	mapFirst := uint64(mapIndex) << params.logValuesPerMap
+
+	for i, row := range rows {
+		rowLen, maxLen := len(row), int(params.maxRowLength(uint32(i)))
+		if rowLen > maxLen {
+			rowLen = maxLen
+		}
+
+		for j := 0; j < rowLen; j++ {
+			if potentialMatch := mapFirst + uint64(row[j]>>(params.logMapWidth-params.logValuesPerMap)); row[j] == params.columnIndex(potentialMatch, &logValue) {
+				results = append(results, potentialMatch)
+			}
+		}
+
+		if rowLen < maxLen {
+			break
+		}
+	}
+
+	// Sort and remove duplicates
+	slices.Sort(results)
+	j := 0
+	for i, match := range results {
+		if i == 0 || match != results[i-1] {
+			results[j] = results[i]
+			j++
+		}
+	}
+
+	return results[:j]
+}

--- a/indexer/filtermap/indexer.go
+++ b/indexer/filtermap/indexer.go
@@ -1,0 +1,221 @@
+package filtermap
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/lru"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+
+	"cosmossdk.io/log"
+	dbm "github.com/cosmos/cosmos-db"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	LogsPerMap          = 65536
+	MapsPerEpoch        = 1024
+	MaxCachedFilterMaps = 100
+
+	KeyPrefixFilterMap    = 0x10
+	KeyPrefixLogData      = 0x11
+	KeyPrefixRawLogs      = 0x12
+	KeyLatestBlock        = 0x13
+	KeyNextMapID          = 0x14
+	KeyPrefixBlockLvPointer = 0x15
+)
+
+type FilterMapsIndexer struct {
+	mu     sync.RWMutex
+	db     dbm.DB
+	logger log.Logger
+	params *Params
+
+	enabled       bool
+	latestBlock   uint64
+	nextMapID     uint32
+	totalLogIndex uint64 // Global log index counter
+
+	// Caches
+	filterMapCache  *lru.Cache[uint32, FilterMap]
+	logDataCache    *lru.Cache[uint32, *LogData]
+	lvPointerCache  *lru.Cache[uint64, uint64]  // block number -> first log index
+	rawLogs         map[uint64][]*ethtypes.Log
+
+	// Current working map
+	currentMap     FilterMap
+	currentLogData *LogData
+	logCounter     uint64 // Counter within current map
+}
+
+func NewFilterMapsIndexer(db dbm.DB, logger log.Logger) *FilterMapsIndexer {
+	params := DefaultParams
+	params.deriveFields()
+
+	return &FilterMapsIndexer{
+		db:             db,
+		logger:         logger.With("module", "filtermaps"),
+		params:         &params,
+		enabled:        true,
+		filterMapCache: lru.NewCache[uint32, FilterMap](MaxCachedFilterMaps),
+		logDataCache:   lru.NewCache[uint32, *LogData](MaxCachedFilterMaps),
+		lvPointerCache: lru.NewCache[uint64, uint64](1000),  // cache last 1000 blocks
+		rawLogs:        make(map[uint64][]*ethtypes.Log),
+	}
+}
+
+func (fmi *FilterMapsIndexer) IndexLogs(blockNumber uint64, logs []*ethtypes.Log) {
+	fmi.mu.Lock()
+	defer fmi.mu.Unlock()
+
+	if !fmi.enabled {
+		return
+	}
+
+	// Store block's first log index even if no logs
+	blockFirstIndex := fmi.totalLogIndex
+	defer func() {
+		fmi.storeBlockLvPointer(blockNumber, blockFirstIndex)
+	}()
+
+	if len(logs) == 0 {
+		return
+	}
+
+	// Initialize current map if needed
+	if fmi.currentMap == nil {
+		fmi.currentMap = NewFilterMap(fmi.params)
+		fmi.currentLogData = &LogData{
+			MapID:      fmi.nextMapID,
+			StartBlock: blockNumber,
+			EndBlock:   blockNumber,
+			Logs:       make([]*ethtypes.Log, 0, LogsPerMap),
+		}
+	}
+
+	// Process each log
+	for _, log := range logs {
+		// Check if current map is full
+		if fmi.logCounter >= LogsPerMap {
+			// Save current map
+			fmi.persistCurrentMap()
+
+			// Start new map
+			fmi.nextMapID++
+			fmi.currentMap = NewFilterMap(fmi.params)
+			fmi.currentLogData = &LogData{
+				MapID:      fmi.nextMapID,
+				StartBlock: blockNumber,
+				EndBlock:   blockNumber,
+				Logs:       make([]*ethtypes.Log, 0, LogsPerMap),
+			}
+			fmi.logCounter = 0
+		}
+
+		// Calculate global log index
+		globalIndex := uint64(fmi.nextMapID)*LogsPerMap + fmi.logCounter
+
+		// Add to filter map
+		fmi.currentMap.AddLogToMap(fmi.params, fmi.nextMapID, globalIndex, log.Address, log.Topics)
+
+		// Add to log data
+		fmi.currentLogData.Logs = append(fmi.currentLogData.Logs, log)
+		fmi.currentLogData.EndBlock = blockNumber
+
+		fmi.logCounter++
+	}
+
+	fmi.latestBlock = blockNumber
+	fmi.totalLogIndex = uint64(fmi.nextMapID)*LogsPerMap + fmi.logCounter
+}
+
+func (fmi *FilterMapsIndexer) GetLogs(
+	ctx sdk.Context,
+	fromBlock, toBlock *big.Int,
+	addresses []common.Address,
+	topics [][]common.Hash,
+) ([]*ethtypes.Log, error) {
+	if !fmi.enabled {
+		return nil, nil
+	}
+
+	var from, to uint64
+	if fromBlock != nil {
+		from = fromBlock.Uint64()
+	}
+	if toBlock != nil {
+		to = toBlock.Uint64()
+	} else {
+		fmi.mu.RLock()
+		to = fmi.latestBlock
+		fmi.mu.RUnlock()
+	}
+
+	return fmi.FindLogsByRange(ctx.Context(), from, to, addresses, topics)
+}
+
+func (fmi *FilterMapsIndexer) persistCurrentMap() {
+	if fmi.currentMap == nil || fmi.currentLogData == nil {
+		return
+	}
+
+	mapKey := append([]byte{KeyPrefixFilterMap}, sdk.Uint64ToBigEndian(uint64(fmi.nextMapID))...)
+	mapData, _ := json.Marshal(fmi.currentMap)
+	fmi.db.Set(mapKey, mapData)
+
+	logKey := append([]byte{KeyPrefixLogData}, sdk.Uint64ToBigEndian(uint64(fmi.nextMapID))...)
+	logData, _ := json.Marshal(fmi.currentLogData)
+	fmi.db.Set(logKey, logData)
+
+	fmi.filterMapCache.Add(fmi.nextMapID, fmi.currentMap)
+	fmi.logDataCache.Add(fmi.nextMapID, fmi.currentLogData)
+}
+
+func (fmi *FilterMapsIndexer) loadFilterMap(mapID uint32) FilterMap {
+	key := append([]byte{KeyPrefixFilterMap}, sdk.Uint64ToBigEndian(uint64(mapID))...)
+	data, err := fmi.db.Get(key)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+
+	var fm FilterMap
+	json.Unmarshal(data, &fm)
+	return fm
+}
+
+func (fmi *FilterMapsIndexer) loadLogData(mapID uint32) *LogData {
+	key := append([]byte{KeyPrefixLogData}, sdk.Uint64ToBigEndian(uint64(mapID))...)
+	data, err := fmi.db.Get(key)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+
+	var ld LogData
+	json.Unmarshal(data, &ld)
+	return &ld
+}
+
+func (fmi *FilterMapsIndexer) storeBlockLvPointer(blockNumber, lvPointer uint64) {
+	fmi.lvPointerCache.Add(blockNumber, lvPointer)
+	key := append([]byte{KeyPrefixBlockLvPointer}, sdk.Uint64ToBigEndian(blockNumber)...)
+	fmi.db.Set(key, sdk.Uint64ToBigEndian(lvPointer))
+}
+
+func (fmi *FilterMapsIndexer) getBlockLvPointer(blockNumber uint64) (uint64, error) {
+	if lvPointer, ok := fmi.lvPointerCache.Get(blockNumber); ok {
+		return lvPointer, nil
+	}
+	
+	key := append([]byte{KeyPrefixBlockLvPointer}, sdk.Uint64ToBigEndian(blockNumber)...)
+	data, err := fmi.db.Get(key)
+	if err != nil || len(data) == 0 {
+		return 0, fmt.Errorf("block %d not indexed yet", blockNumber)
+	}
+	
+	lvPointer := sdk.BigEndianToUint64(data)
+	fmi.lvPointerCache.Add(blockNumber, lvPointer)
+	return lvPointer, nil
+}

--- a/indexer/filtermap/indexer_test.go
+++ b/indexer/filtermap/indexer_test.go
@@ -1,0 +1,282 @@
+package filtermap
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	
+	dbm "github.com/cosmos/cosmos-db"
+	"cosmossdk.io/log"
+	
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockLvPointer(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	logs1 := []*ethtypes.Log{
+		{Address: common.HexToAddress("0x1"), Topics: []common.Hash{{0x1}}},
+		{Address: common.HexToAddress("0x2"), Topics: []common.Hash{{0x2}}},
+		{Address: common.HexToAddress("0x3"), Topics: []common.Hash{{0x3}}},
+	}
+	indexer.IndexLogs(1, logs1)
+	
+	indexer.IndexLogs(2, []*ethtypes.Log{})
+	
+	logs3 := []*ethtypes.Log{
+		{Address: common.HexToAddress("0x4"), Topics: []common.Hash{{0x4}}},
+		{Address: common.HexToAddress("0x5"), Topics: []common.Hash{{0x5}}},
+	}
+	indexer.IndexLogs(3, logs3)
+	
+	ptr1, err := indexer.getBlockLvPointer(1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), ptr1)
+	
+	ptr2, err := indexer.getBlockLvPointer(2)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), ptr2)
+	
+	ptr3, err := indexer.getBlockLvPointer(3)
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), ptr3)
+	
+	firstIdx, lastIdx := indexer.getLogIndexRange(1, 3)
+	require.Equal(t, uint64(0), firstIdx)
+	require.Equal(t, uint64(4), lastIdx)
+}
+
+func TestBlockLvPointerWithManyLogs(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	for block := uint64(1); block <= 1000; block++ {
+		var logs []*ethtypes.Log
+		numLogs := (block % 100) + 1
+		for i := uint64(0); i < numLogs; i++ {
+			logs = append(logs, &ethtypes.Log{
+				Address: common.HexToAddress("0x1"),
+				Topics:  []common.Hash{{byte(i)}},
+			})
+		}
+		indexer.IndexLogs(block, logs)
+	}
+	
+	ptr1, err := indexer.getBlockLvPointer(1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), ptr1)
+	
+	ptr500, err := indexer.getBlockLvPointer(500)
+	require.NoError(t, err)
+	require.Greater(t, ptr500, uint64(10000))
+	
+	firstIdx, lastIdx := indexer.getLogIndexRange(100, 200)
+	require.Less(t, firstIdx, lastIdx)
+	
+	_, err = indexer.getBlockLvPointer(500)
+	require.NoError(t, err)
+}
+
+func TestMapBoundaryTransition(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	logsPerBlock := 1000
+	blocksForFirstMap := (LogsPerMap / logsPerBlock) + 1
+	
+	totalLogs := uint64(0)
+	for block := uint64(1); block <= uint64(blocksForFirstMap); block++ {
+		var logs []*ethtypes.Log
+		numLogs := logsPerBlock
+		if totalLogs + uint64(numLogs) > LogsPerMap {
+			numLogs = int(LogsPerMap - totalLogs)
+		}
+		for i := 0; i < numLogs; i++ {
+			logs = append(logs, &ethtypes.Log{
+				Address: common.HexToAddress("0x1"),
+				Topics:  []common.Hash{{byte(i)}},
+			})
+		}
+		indexer.IndexLogs(block, logs)
+		totalLogs += uint64(numLogs)
+		
+		if totalLogs >= LogsPerMap {
+			break
+		}
+	}
+	
+	require.Equal(t, uint64(LogsPerMap), indexer.totalLogIndex)
+	require.Equal(t, uint64(LogsPerMap), indexer.logCounter)
+	require.Equal(t, uint32(0), indexer.nextMapID)
+	
+	extraLogs := []*ethtypes.Log{{
+		Address: common.HexToAddress("0x2"),
+		Topics:  []common.Hash{{0xff}},
+	}}
+	indexer.IndexLogs(100, extraLogs)
+	
+	require.Equal(t, uint32(1), indexer.nextMapID)
+	require.Equal(t, uint64(1), indexer.logCounter)
+	
+	ptr, err := indexer.getBlockLvPointer(100)
+	require.NoError(t, err)
+	require.Equal(t, uint64(LogsPerMap), ptr)
+}
+
+func TestFilterMapSearch(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	targetAddr := common.HexToAddress("0xDEADBEEF")
+	targetTopic := common.HexToHash("0xCAFEBABE")
+	
+	logs1 := []*ethtypes.Log{
+		{
+			Address:     targetAddr,
+			Topics:      []common.Hash{targetTopic},
+			BlockNumber: 1,
+		},
+		{
+			Address:     common.HexToAddress("0x1"),
+			Topics:      []common.Hash{{0x1}},
+			BlockNumber: 1,
+		},
+	}
+	indexer.IndexLogs(1, logs1)
+	
+	logs2 := []*ethtypes.Log{
+		{
+			Address:     common.HexToAddress("0x2"),
+			Topics:      []common.Hash{{0x2}},
+			BlockNumber: 2,
+		},
+	}
+	indexer.IndexLogs(2, logs2)
+	
+	logs3 := []*ethtypes.Log{
+		{
+			Address:     targetAddr,
+			Topics:      []common.Hash{targetTopic, {0x3}},
+			BlockNumber: 3,
+		},
+	}
+	indexer.IndexLogs(3, logs3)
+	
+	ctx := &mockContext{}
+	results, err := indexer.FindLogsByRange(
+		ctx.Context(),
+		1, 3,
+		[]common.Address{targetAddr},
+		[][]common.Hash{{targetTopic}},
+	)
+	
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	
+	for _, log := range results {
+		require.Equal(t, targetAddr, log.Address)
+		require.Equal(t, targetTopic, log.Topics[0])
+	}
+}
+
+func TestEmptyBlockHandling(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	indexer.IndexLogs(1, []*ethtypes.Log{})
+	indexer.IndexLogs(2, []*ethtypes.Log{
+		{Address: common.HexToAddress("0x1"), Topics: []common.Hash{{0x1}}},
+	})
+	indexer.IndexLogs(3, []*ethtypes.Log{})
+	indexer.IndexLogs(4, []*ethtypes.Log{})
+	indexer.IndexLogs(5, []*ethtypes.Log{
+		{Address: common.HexToAddress("0x2"), Topics: []common.Hash{{0x2}}},
+		{Address: common.HexToAddress("0x3"), Topics: []common.Hash{{0x3}}},
+	})
+	
+	ptr1, _ := indexer.getBlockLvPointer(1)
+	ptr2, _ := indexer.getBlockLvPointer(2)
+	ptr3, _ := indexer.getBlockLvPointer(3)
+	ptr4, _ := indexer.getBlockLvPointer(4)
+	ptr5, _ := indexer.getBlockLvPointer(5)
+	
+	require.Equal(t, uint64(0), ptr1)
+	require.Equal(t, uint64(0), ptr2)
+	require.Equal(t, uint64(1), ptr3)
+	require.Equal(t, uint64(1), ptr4)
+	require.Equal(t, uint64(1), ptr5)
+	
+	require.Equal(t, uint64(3), indexer.totalLogIndex)
+}
+
+func TestPersistenceAcrossRestart(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	
+	indexer1 := NewFilterMapsIndexer(db, logger)
+	
+	logs := []*ethtypes.Log{
+		{Address: common.HexToAddress("0x1"), Topics: []common.Hash{{0x1}}},
+		{Address: common.HexToAddress("0x2"), Topics: []common.Hash{{0x2}}},
+	}
+	indexer1.IndexLogs(1, logs)
+	indexer1.IndexLogs(2, logs)
+	
+	ptr1Before, err := indexer1.getBlockLvPointer(1)
+	require.NoError(t, err)
+	ptr2Before, err := indexer1.getBlockLvPointer(2)
+	require.NoError(t, err)
+	
+	indexer2 := NewFilterMapsIndexer(db, logger)
+	
+	ptr1After, err := indexer2.getBlockLvPointer(1)
+	require.NoError(t, err)
+	ptr2After, err := indexer2.getBlockLvPointer(2)
+	require.NoError(t, err)
+	
+	require.Equal(t, ptr1Before, ptr1After)
+	require.Equal(t, ptr2Before, ptr2After)
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	db := dbm.NewMemDB()
+	logger := log.NewNopLogger()
+	indexer := NewFilterMapsIndexer(db, logger)
+	
+	for i := uint64(1); i <= 100; i++ {
+		logs := []*ethtypes.Log{{
+			Address: common.HexToAddress("0x1"),
+			Topics:  []common.Hash{{byte(i)}},
+		}}
+		indexer.IndexLogs(i, logs)
+	}
+	
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := uint64(1); j <= 100; j++ {
+				_, err := indexer.getBlockLvPointer(j)
+				require.NoError(t, err)
+			}
+		}(i)
+	}
+	
+	wg.Wait()
+}
+
+type mockContext struct{}
+
+func (m *mockContext) Context() context.Context {
+	return context.Background()
+}

--- a/indexer/filtermap/matcher.go
+++ b/indexer/filtermap/matcher.go
@@ -1,0 +1,317 @@
+package filtermap
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/filtermaps"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func (fmi *FilterMapsIndexer) FindLogsByRange(
+	ctx context.Context,
+	firstBlock, lastBlock uint64,
+	addresses []common.Address,
+	topics [][]common.Hash,
+) ([]*types.Log, error) {
+	firstIndex, lastIndex := fmi.getLogIndexRange(firstBlock, lastBlock)
+	if firstIndex > lastIndex {
+		return nil, nil
+	}
+
+	m := &matcher{
+		ctx:        ctx,
+		indexer:    fmi,
+		params:     fmi.params,
+		addresses:  addresses,
+		topics:     topics,
+		firstBlock: firstBlock,
+		lastBlock:  lastBlock,
+		firstIndex: firstIndex,
+		lastIndex:  lastIndex,
+		firstMap:   uint32(firstIndex >> fmi.params.logValuesPerMap),
+		lastMap:    uint32(lastIndex >> fmi.params.logValuesPerMap),
+	}
+
+	return m.process()
+}
+
+type matcher struct {
+	ctx                   context.Context
+	indexer               *FilterMapsIndexer
+	params                *Params
+	addresses             []common.Address
+	topics                [][]common.Hash
+	firstBlock, lastBlock uint64 // Block range
+	firstIndex, lastIndex uint64 // Log index range
+	firstMap, lastMap     uint32
+}
+
+func (m *matcher) process() ([]*types.Log, error) {
+	type task struct {
+		epochIndex uint32
+		logs       []*types.Log
+		err        error
+		done       chan struct{}
+	}
+
+	taskCh := make(chan *task)
+	var wg sync.WaitGroup
+	defer func() {
+		close(taskCh)
+		wg.Wait()
+	}()
+
+	worker := func() {
+		for task := range taskCh {
+			if task == nil {
+				break
+			}
+			task.logs, task.err = m.processEpoch(task.epochIndex)
+			close(task.done)
+		}
+		wg.Done()
+	}
+
+	for range 4 {
+		wg.Add(1)
+		go worker()
+	}
+
+	firstEpoch := m.firstMap >> m.params.logMapsPerEpoch
+	lastEpoch := m.lastMap >> m.params.logMapsPerEpoch
+
+	var logs []*types.Log
+	startEpoch, waitEpoch := firstEpoch, firstEpoch
+	tasks := make(map[uint32]*task)
+	tasks[startEpoch] = &task{epochIndex: startEpoch, done: make(chan struct{})}
+
+	for waitEpoch <= lastEpoch {
+		select {
+		case taskCh <- tasks[startEpoch]:
+			startEpoch++
+			if startEpoch <= lastEpoch {
+				if tasks[startEpoch] == nil {
+					tasks[startEpoch] = &task{epochIndex: startEpoch, done: make(chan struct{})}
+				}
+			}
+
+		case <-tasks[waitEpoch].done:
+			if tasks[waitEpoch].err != nil {
+				return nil, tasks[waitEpoch].err
+			}
+			logs = append(logs, tasks[waitEpoch].logs...)
+			delete(tasks, waitEpoch)
+			waitEpoch++
+
+		case <-m.ctx.Done():
+			return nil, m.ctx.Err()
+		}
+	}
+
+	return logs, nil
+}
+
+func (m *matcher) processEpoch(epochIndex uint32) ([]*types.Log, error) {
+	firstMap := epochIndex << m.params.logMapsPerEpoch
+	lastMap := firstMap + m.params.mapsPerEpoch - 1
+	if firstMap < m.firstMap {
+		firstMap = m.firstMap
+	}
+	if lastMap > m.lastMap {
+		lastMap = m.lastMap
+	}
+
+	var logs []*types.Log
+	for mapIndex := firstMap; mapIndex <= lastMap; mapIndex++ {
+		mapLogs := m.processMap(mapIndex)
+		logs = append(logs, mapLogs...)
+	}
+
+	return logs, nil
+}
+
+func (m *matcher) processMap(mapIndex uint32) []*types.Log {
+	fm := m.indexer.getFilterMap(mapIndex)
+	if fm == nil {
+		return nil
+	}
+
+	logData := m.indexer.getLogData(mapIndex)
+	if logData == nil {
+		return nil
+	}
+
+	matches := make(map[uint64]bool)
+
+	if len(m.addresses) > 0 {
+		for _, addr := range m.addresses {
+			addrValue := addressValue(addr)
+			rows := m.getRowsForValue(fm, mapIndex, addrValue)
+			potentials := m.params.potentialMatches(rows, mapIndex, addrValue)
+			for _, p := range potentials {
+				matches[p] = true
+			}
+		}
+	} else {
+		mapFirst := uint64(mapIndex) << m.params.logValuesPerMap
+		for i := uint64(0); i < uint64(len(logData.Logs)); i++ {
+			matches[mapFirst+i] = true
+		}
+	}
+
+	for _, topicList := range m.topics {
+		if len(topicList) == 0 {
+			continue
+		}
+
+		topicMatches := make(map[uint64]bool)
+		for _, topic := range topicList {
+			topicVal := topicValue(topic)
+			rows := m.getRowsForValue(fm, mapIndex, topicVal)
+			potentials := m.params.potentialMatches(rows, mapIndex, topicVal)
+			for _, p := range potentials {
+				if matches[p] {
+					topicMatches[p] = true
+				}
+			}
+		}
+
+		matches = topicMatches
+	}
+
+	var result []*types.Log
+	mapFirst := uint64(mapIndex) << m.params.logValuesPerMap
+
+	for matchIdx := range matches {
+		localIdx := matchIdx - mapFirst
+		if localIdx >= uint64(len(logData.Logs)) {
+			continue
+		}
+
+		log := logData.Logs[localIdx]
+
+		if log.BlockNumber < m.firstBlock || log.BlockNumber > m.lastBlock {
+			continue
+		}
+
+		if m.verifyLog(log) {
+			result = append(result, log)
+		}
+	}
+
+	return result
+}
+
+func (m *matcher) getRowsForValue(fm FilterMap, mapIndex uint32, logValue common.Hash) []filtermaps.FilterRow {
+	var rows []filtermaps.FilterRow
+	for layerIndex := uint32(0); ; layerIndex++ {
+		rowIdx := m.params.rowIndex(mapIndex, layerIndex, logValue)
+		if rowIdx >= uint32(len(fm)) || fm[rowIdx] == nil {
+			break
+		}
+
+		rows = append(rows, fm[rowIdx])
+
+		if len(fm[rowIdx]) < int(m.params.maxRowLength(layerIndex)) {
+			break
+		}
+	}
+	return rows
+}
+
+func (m *matcher) verifyLog(log *types.Log) bool {
+	if len(m.addresses) > 0 {
+		if !slices.Contains(m.addresses, log.Address) {
+			return false
+		}
+	}
+
+	for i, topicList := range m.topics {
+		if len(topicList) == 0 {
+			continue
+		}
+		if i >= len(log.Topics) {
+			return false
+		}
+
+		if !slices.Contains(topicList, log.Topics[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (fmi *FilterMapsIndexer) getLogIndexRange(firstBlock, lastBlock uint64) (uint64, uint64) {
+	fmi.mu.RLock()
+	defer fmi.mu.RUnlock()
+
+	if lastBlock > fmi.latestBlock {
+		lastBlock = fmi.latestBlock
+	}
+
+	// Get exact log index from BlockLvPointer
+	firstIndex, err := fmi.getBlockLvPointer(firstBlock)
+	if err != nil {
+		// Fallback to estimation if block not indexed yet
+		firstIndex = firstBlock * 10
+	}
+	
+	lastIndex, err := fmi.getBlockLvPointer(lastBlock + 1)
+	if err != nil {
+		// Fallback to estimation if block not indexed yet
+		lastIndex = (lastBlock + 1) * 10
+		if lastIndex > fmi.totalLogIndex {
+			lastIndex = fmi.totalLogIndex
+		}
+	}
+
+	if lastIndex > 0 {
+		lastIndex--
+	}
+
+	return firstIndex, lastIndex
+}
+
+func (fmi *FilterMapsIndexer) getFilterMap(mapIndex uint32) FilterMap {
+	fmi.mu.RLock()
+	defer fmi.mu.RUnlock()
+
+	if mapIndex == fmi.nextMapID && fmi.currentMap != nil {
+		return fmi.currentMap
+	}
+
+	if fm, ok := fmi.filterMapCache.Get(mapIndex); ok {
+		return fm
+	}
+
+	fm := fmi.loadFilterMap(mapIndex)
+	if fm != nil {
+		fmi.filterMapCache.Add(mapIndex, fm)
+	}
+
+	return fm
+}
+
+func (fmi *FilterMapsIndexer) getLogData(mapIndex uint32) *LogData {
+	fmi.mu.RLock()
+	defer fmi.mu.RUnlock()
+
+	if mapIndex == fmi.nextMapID && fmi.currentLogData != nil {
+		return fmi.currentLogData
+	}
+
+	if ld, ok := fmi.logDataCache.Get(mapIndex); ok {
+		return ld
+	}
+
+	ld := fmi.loadLogData(mapIndex)
+	if ld != nil {
+		fmi.logDataCache.Add(mapIndex, ld)
+	}
+
+	return ld
+}

--- a/indexer/filtermap/params.go
+++ b/indexer/filtermap/params.go
@@ -1,0 +1,100 @@
+package filtermap
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"hash/fnv"
+	"math"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// copy from github.com/ethereum/go-ethereum/core/filtermaps/math.go
+
+type Params struct {
+	logMapHeight       uint
+	logMapWidth        uint
+	logMapsPerEpoch    uint
+	logValuesPerMap    uint
+	baseRowLengthRatio uint
+	logLayerDiff       uint
+	mapHeight          uint32
+	mapsPerEpoch       uint32
+	baseRowLength      uint32
+	valuesPerMap       uint64
+}
+
+var DefaultParams = Params{
+	logMapHeight:       16,
+	logMapWidth:        24,
+	logMapsPerEpoch:    10,
+	logValuesPerMap:    16,
+	baseRowLengthRatio: 8,
+	logLayerDiff:       4,
+}
+
+func init() {
+	DefaultParams.deriveFields()
+}
+
+func (p *Params) deriveFields() {
+	p.mapHeight = uint32(1) << p.logMapHeight
+	p.mapsPerEpoch = uint32(1) << p.logMapsPerEpoch
+	p.valuesPerMap = uint64(1) << p.logValuesPerMap
+	p.baseRowLength = uint32(p.valuesPerMap * uint64(p.baseRowLengthRatio) / uint64(p.mapHeight))
+}
+
+func addressValue(address common.Address) common.Hash {
+	var result common.Hash
+	hasher := sha256.New()
+	hasher.Write(address[:])
+	hasher.Sum(result[:0])
+	return result
+}
+
+func topicValue(topic common.Hash) common.Hash {
+	var result common.Hash
+	hasher := sha256.New()
+	hasher.Write(topic[:])
+	hasher.Sum(result[:0])
+	return result
+}
+
+func (p *Params) rowIndex(mapIndex, layerIndex uint32, logValue common.Hash) uint32 {
+	hasher := sha256.New()
+	hasher.Write(logValue[:])
+	var indexEnc [8]byte
+	binary.LittleEndian.PutUint32(indexEnc[0:4], p.maskedMapIndex(mapIndex, layerIndex))
+	binary.LittleEndian.PutUint32(indexEnc[4:8], layerIndex)
+	hasher.Write(indexEnc[:])
+	var hash common.Hash
+	hasher.Sum(hash[:0])
+	return binary.LittleEndian.Uint32(hash[:4]) % p.mapHeight
+}
+
+func (p *Params) columnIndex(lvIndex uint64, logValue *common.Hash) uint32 {
+	var indexEnc [8]byte
+	binary.LittleEndian.PutUint64(indexEnc[:], lvIndex)
+	hasher := fnv.New64a()
+	hasher.Write(indexEnc[:])
+	hasher.Write(logValue[:])
+	hash := hasher.Sum64()
+	hashBits := p.logMapWidth - p.logValuesPerMap
+	return uint32(lvIndex%p.valuesPerMap)<<hashBits + (uint32(hash>>(64-hashBits)) ^ uint32(hash)>>(32-hashBits))
+}
+
+func (p *Params) maskedMapIndex(mapIndex, layerIndex uint32) uint32 {
+	logLayerDiff := uint(layerIndex) * p.logLayerDiff
+	if logLayerDiff > p.logMapsPerEpoch {
+		logLayerDiff = p.logMapsPerEpoch
+	}
+	return mapIndex & (uint32(math.MaxUint32) << (p.logMapsPerEpoch - logLayerDiff))
+}
+
+func (p *Params) maxRowLength(layerIndex uint32) uint32 {
+	logLayerDiff := uint(layerIndex) * p.logLayerDiff
+	if logLayerDiff > p.logMapsPerEpoch {
+		logLayerDiff = p.logMapsPerEpoch
+	}
+	return p.baseRowLength << logLayerDiff
+}

--- a/rpc/namespaces/ethereum/eth/filters/api.go
+++ b/rpc/namespaces/ethereum/eth/filters/api.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/cosmos/evm/rpc/types"
 	evmtypes "github.com/cosmos/evm/x/vm/types"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"cosmossdk.io/log"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -52,6 +54,7 @@ type Backend interface {
 	BlockBloom(blockRes *coretypes.ResultBlockResults) (ethtypes.Bloom, error)
 
 	BloomStatus() (uint64, uint64)
+	GetFilterLogs(ctx sdk.Context, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) ([]*ethtypes.Log, error)
 
 	RPCFilterCap() int32
 	RPCLogsCap() int32

--- a/x/vm/keeper/abci.go
+++ b/x/vm/keeper/abci.go
@@ -1,11 +1,7 @@
 package keeper
 
 import (
-	ethtypes "github.com/ethereum/go-ethereum/core/types"
-
 	evmtypes "github.com/cosmos/evm/x/vm/types"
-
-	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -34,15 +30,10 @@ func (k *Keeper) BeginBlock(ctx sdk.Context) error {
 	return nil
 }
 
-// EndBlock also retrieves the bloom filter value from the transient store and commits it to the
-// KVStore. The EVM end block logic doesn't update the validator set, thus it returns
+// EndBlock performs end block logic for the EVM module.
+// The EVM end block logic doesn't update the validator set, thus it returns
 // an empty slice.
 func (k *Keeper) EndBlock(ctx sdk.Context) error {
-	// Gas costs are handled within msg handler so costs should be ignored
-	infCtx := ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
-
-	bloom := ethtypes.BytesToBloom(k.GetBlockBloomTransient(infCtx).Bytes())
-	k.EmitBlockBloomEvent(infCtx, bloom)
-
+	// No bloom filter operations needed - using filtermaps instead
 	return nil
 }

--- a/x/vm/keeper/keeper.go
+++ b/x/vm/keeper/keeper.go
@@ -19,7 +19,6 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
-	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -124,39 +123,9 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // Required by Web3 API.
 // ----------------------------------------------------------------------------
 
-// EmitBlockBloomEvent emit block bloom events
-func (k Keeper) EmitBlockBloomEvent(ctx sdk.Context, bloom ethtypes.Bloom) {
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeBlockBloom,
-			sdk.NewAttribute(types.AttributeKeyEthereumBloom, string(bloom.Bytes())),
-		),
-	)
-}
-
 // GetAuthority returns the x/evm module authority address
 func (k Keeper) GetAuthority() sdk.AccAddress {
 	return k.authority
-}
-
-// GetBlockBloomTransient returns bloom bytes for the current block height
-func (k Keeper) GetBlockBloomTransient(ctx sdk.Context) *big.Int {
-	store := prefix.NewStore(ctx.TransientStore(k.transientKey), types.KeyPrefixTransientBloom)
-	heightBz := sdk.Uint64ToBigEndian(uint64(ctx.BlockHeight())) //nolint:gosec // G115 // won't exceed uint64
-	bz := store.Get(heightBz)
-	if len(bz) == 0 {
-		return big.NewInt(0)
-	}
-
-	return new(big.Int).SetBytes(bz)
-}
-
-// SetBlockBloomTransient sets the given bloom bytes to the transient store. This value is reset on
-// every block.
-func (k Keeper) SetBlockBloomTransient(ctx sdk.Context, bloom *big.Int) {
-	store := prefix.NewStore(ctx.TransientStore(k.transientKey), types.KeyPrefixTransientBloom)
-	heightBz := sdk.Uint64ToBigEndian(uint64(ctx.BlockHeight())) //nolint:gosec // G115 // won't exceed uint64
-	store.Set(heightBz, bloom.Bytes())
 }
 
 // ----------------------------------------------------------------------------

--- a/x/vm/types/events.go
+++ b/x/vm/types/events.go
@@ -3,7 +3,7 @@ package types
 // Evm module events
 const (
 	EventTypeEthereumTx = TypeMsgEthereumTx
-	EventTypeBlockBloom = "block_bloom"
+	EventTypeBlockBloom = "block_bloom" // DEPRECATED: Using FilterMaps instead
 	EventTypeTxLog      = "tx_log"
 	EventTypeFeeMarket  = "evm_fee_market"
 
@@ -20,7 +20,7 @@ const (
 	// tx failed in eth vm execution
 	AttributeKeyEthereumTxFailed = "ethereumTxFailed"
 	AttributeValueCategory       = ModuleName
-	AttributeKeyEthereumBloom    = "bloom"
+	AttributeKeyEthereumBloom    = "bloom" // DEPRECATED: Using FilterMaps instead
 
 	MetricKeyTransitionDB = "transition_db"
 	MetricKeyStaticCall   = "static_call"

--- a/x/vm/types/key.go
+++ b/x/vm/types/key.go
@@ -31,7 +31,7 @@ const (
 
 // prefix bytes for the EVM transient store
 const (
-	prefixTransientBloom = iota + 1
+	prefixTransientBloom = iota + 1 // DEPRECATED: Using FilterMaps instead
 	prefixTransientTxIndex
 	prefixTransientLogSize
 	prefixTransientGasUsed
@@ -47,7 +47,7 @@ var (
 
 // Transient Store key prefixes
 var (
-	KeyPrefixTransientBloom   = []byte{prefixTransientBloom}
+	KeyPrefixTransientBloom   = []byte{prefixTransientBloom} // DEPRECATED: Using FilterMaps instead
 	KeyPrefixTransientTxIndex = []byte{prefixTransientTxIndex}
 	KeyPrefixTransientLogSize = []byte{prefixTransientLogSize}
 	KeyPrefixTransientGasUsed = []byte{prefixTransientGasUsed}


### PR DESCRIPTION
# Description

  Implements Ethereum's FilterMaps (EIP-7745) for efficient log retrieval, replacing
  bloom filters with a more accurate and performant lazy indexing system.

## Motivation
- Bloom filters limitations: High false positive rates, inefficient for sparse logs,
  large storage overhead

 - FilterMaps advantages: Direct mapping with minimal false positives, efficient sparse
  log handling, better query performance

## Features

  - Lazy Indexing: Build FilterMaps only when queries request specific ranges
  - Decoupled Processing: Indexer operates independently from consensus